### PR TITLE
feat: add support for docker/build-push-action's target argument

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -8,6 +8,9 @@ inputs:
   build-args:
     description: The arguments to build the image with
     required: false
+  target:
+    description: The target stage to build
+    required: false
   name:
     description: The name to call the image
     required: true
@@ -33,6 +36,7 @@ runs:
         cache-to: type=gha,scope=${{ inputs.file || 'Dockerfile' }}
         tags: |
           ${{ inputs.name }}
+        target: ${{ inputs.target }}
         outputs: type=docker,dest=/tmp/${{ inputs.name }}.tar
 
     - name: Upload artifact


### PR DESCRIPTION
Adds support for [docker/build-push-actions](https://github.com/docker/build-push-action#inputs)'s target stage argument. Can be used to for example only build one stage of a Dockerfile.