### PR TITLE
feat: allow setting the build context

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -2,9 +2,14 @@ name: Build Docker image
 description: Build a Docker image and optionally upload it as artifact
 
 inputs:
+  context:
+    description: The build's context
+    required: false
+    default: .
   file:
     description: Path to the Dockerfile to build
     required: false
+    default: Dockerfile
   build-args:
     description: The arguments to build the image with
     required: false
@@ -28,12 +33,12 @@ runs:
     - name: Build image
       uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # tag=v3.0.0
       with:
-        context: .
+        context: ${{ inputs.context }}
         file: ${{ inputs.file }}
         build-args: |
           ${{ inputs.build-args }}
-        cache-from: type=gha,scope=${{ inputs.file || 'Dockerfile' }}
-        cache-to: type=gha,scope=${{ inputs.file || 'Dockerfile' }}
+        cache-from: type=gha,scope=${{ format('{0}/{1}', inputs.context, inputs.file) }}
+        cache-to: type=gha,scope=${{ format('{0}/{1}', inputs.context, inputs.file) }}
         tags: |
           ${{ inputs.name }}
         target: ${{ inputs.target }}


### PR DESCRIPTION
Allows setting `docker/build-push-action`'s context input.