### PR TITLE
fix: only include file in cache scopes

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -37,8 +37,8 @@ runs:
         file: ${{ inputs.file }}
         build-args: |
           ${{ inputs.build-args }}
-        cache-from: type=gha,scope=${{ format('{0}/{1}', inputs.context, inputs.file) }}
-        cache-to: type=gha,scope=${{ format('{0}/{1}', inputs.context, inputs.file) }}
+        cache-from: type=gha,scope=${{ inputs.file }}
+        cache-to: type=gha,scope=${{ inputs.file }}
         tags: |
           ${{ inputs.name }}
         target: ${{ inputs.target }}


### PR DESCRIPTION
Because the file includes the context, including the context in the scope would be duplicate.