### PR TITLE
refactor(semantic-release): bump patch on chore/refactor

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,15 @@
 {
   "branches": ["main"],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          { "type": "chore", "release": "patch" },
+          { "type": "refactor", "release": "patch" }
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
   ]


### PR DESCRIPTION
The default commit-analyzer plugin configuration does not include these update types.