### PR TITLE
fix(semantic-release): include all update types in config

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -17,8 +17,18 @@
         "preset": "conventionalcommits",
         "presetConfig": {
           "types": [
-            { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
-            { "type": "refactor", "section": "Code Refactors", "hidden": false }
+            { "type": "feat", "section": "Features" },
+            { "type": "feature", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "style", "section": "Styles", "hidden": true },
+            { "type": "chore", "section": "Miscellaneous Chores" },
+            { "type": "refactor", "section": "Code Refactoring" },
+            { "type": "test", "section": "Tests", "hidden": true },
+            { "type": "build", "section": "Build System", "hidden": true },
+            { "type": "ci", "section": "Continuous Integration", "hidden": true }
           ]
         }
       }


### PR DESCRIPTION
Thought it merged, but apparently it overrides.