### PR TITLE
fix(semantic-release): pin conventionalcommits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,5 +29,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm install conventional-changelog-conventionalcommits -D
+          npm install conventional-changelog-conventionalcommits@7.0.2 -D
           npx semantic-release@23.0.8


### PR DESCRIPTION
New major version of semantic-release [breaks it](https://github.com/guidojw/actions/actions/runs/8952604445/job/24590172941)

Issue ref: https://github.com/semantic-release/release-notes-generator/issues/633#issuecomment-2094571737