### PR TITLE
fix(build-docker-image): only scope cache to file

### DIFF
--- a/build-docker-image/action.yml
+++ b/build-docker-image/action.yml
@@ -37,8 +37,8 @@ runs:
         file: ${{ inputs.file }}
         build-args: |
           ${{ inputs.build-args }}
-        cache-from: type=gha,scope=${{ github.ref_name }}-${{ inputs.file }}-${{ inputs.target || 'main' }}
-        cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ inputs.file }}-${{ inputs.target || 'main' }}
+        cache-from: type=gha,scope=${{ inputs.file }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.file }}
         tags: |
           ${{ inputs.name }}
         target: ${{ inputs.target }}


### PR DESCRIPTION
Was using it incorrectly all this time, this fix should result in way more cache hits increasing workflow execution times.